### PR TITLE
feat: Add manual CI/CD deploy workflow for self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy Services
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Pull latest changes
+        run: |
+          cd ~/workspace/home-server
+          git pull origin master
+
+      - name: Detect changed service folders and deploy
+        run: |
+          cd ~/workspace/home-server
+
+          # Get list of changed files between last two commits
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Known stacks in priority order (most specific first)
+          STACKS=(
+            "media/apps/immich"
+            "media/apps"
+            "media/services"
+            "dashboard"
+            "monitoring"
+            "networking"
+          )
+
+          DEPLOYED=()
+
+          for STACK in "${STACKS[@]}"; do
+            # Check if any changed file falls under this stack
+            if echo "$CHANGED_FILES" | grep -q "^${STACK}/"; then
+              # Skip if a more specific sub-stack was already deployed
+              SKIP=false
+              for DONE in "${DEPLOYED[@]}"; do
+                if [[ "$DONE" == "${STACK}/"* ]]; then
+                  SKIP=true
+                  break
+                fi
+              done
+
+              if [ "$SKIP" = false ] && [ -f "${STACK}/docker-compose.yaml" ]; then
+                echo "--- Deploying stack: $STACK ---"
+                cd ~/workspace/home-server/${STACK}
+                docker compose pull
+                docker compose up -d --build
+                cd ~/workspace/home-server
+                DEPLOYED+=("$STACK")
+              fi
+            fi
+          done
+
+          if [ ${#DEPLOYED[@]} -eq 0 ]; then
+            echo "No service stacks affected by this commit."
+          fi
+
+      - name: Verify — list any exited containers
+        run: |
+          echo "=== Exited containers ==="
+          docker ps --filter status=exited


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/deploy.yml`) that enables manual one-click deployments to **indika-media** via the self-hosted runner.

## How it works

- **Trigger**: `workflow_dispatch` only — a manual "Run workflow" button in the Actions tab. No automatic deploys on push.
- **No `actions/checkout`**: Every step operates directly on the existing clone at `~/workspace/home-server`, so your local `.env` files and gitignored secrets remain untouched.
- **Smart stack detection**: Diffs `HEAD~1..HEAD` to find which files changed, then maps each changed file to its nearest parent folder that contains a `docker-compose.yaml`. The `media/apps/immich` nested stack is treated as its own independent stack and won't trigger a redundant `media/apps` deploy.
- **Deploy steps per affected stack**: `docker compose pull && docker compose up -d --build`
- **Verification step**: Prints any exited containers via `docker ps --filter status=exited` so failures are immediately visible in the run log.

## Stacks covered

| Folder | Stack |
|---|---|
| `media/apps/immich` | Immich (treated independently) |
| `media/apps` | Sonarr, Radarr, Prowlarr, qBittorrent |
| `media/services` | Plex / media services |
| `dashboard` | Homepage dashboard |
| `monitoring` | Grafana + Prometheus |
| `networking` | Tailscale / networking |

## Secrets policy

No secrets stored in this workflow or GitHub Secrets. `.env` files stay local and gitignored per existing policy.

## Next steps after merge

1. Set up branch protection on `master` (require PR, block direct pushes)
2. Test via Actions tab → "Deploy Services" → "Run workflow"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered deployment workflow for affected service stacks.
  * Automatically identifies changed services and deploys only the relevant stacks.
  * Updates and rebuilds selected services, then reports any exited containers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->